### PR TITLE
Fix path to compiled program

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,10 @@ jobs:
       - name: Package artefacts
         run: |
           mkdir -p artefacts
-          cp program/programs/futurity/target/deploy/futurity.so artefacts/
+          # The build step above runs in the `program` directory, so the
+          # compiled shared object is output to `program/target/deploy`.
+          # Copy it from there for later steps.
+          cp program/target/deploy/futurity.so artefacts/
           shasum -a 256 artefacts/futurity.so > artefacts/futurity.sha256
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- copy the Futurity program from the correct build output directory

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6846591144488333a589c37a9b0f5a07